### PR TITLE
use embeddings directory from cmd_opts for saving

### DIFF
--- a/scripts/embedding_inspector.py
+++ b/scripts/embedding_inspector.py
@@ -6,6 +6,7 @@
 
 import gradio as gr
 from modules import script_callbacks, shared, sd_hijack
+from modules.shared import cmd_opts
 import torch, os
 from modules.textual_inversion.textual_inversion import Embedding
 import math, random
@@ -274,7 +275,7 @@ def do_save(*args):
             preset_name = '_'+EVAL_PRESETS[preset_no*2]
             eval_txt = EVAL_PRESETS[preset_no*2+1]
 
-        save_filename = 'embeddings/'+save_name+preset_name+'.bin'
+        save_filename = os.path.join(cmd_opts.embeddings_dir, save_name+preset_name+'.bin')
         file_exists = os.path.exists(save_filename)
         if (file_exists):
             if not(enable_overwrite):


### PR DESCRIPTION
I have all my embeddings/hns stored outside the installation folder and use the cli arguments provided when starting. I noticed that embeddings saved with the inspector will still save in the webui folder instead of the provided one, which makes it a bit of a hassle having to copy them over each time. 

This fix uses the provided cmd_opts.embeddings_dir instead of the hardcoded one, which will point to either the default embeddings folder or the user specified --embeddings-dir if that option was used.